### PR TITLE
Fixed memory leaks caused by Context

### DIFF
--- a/app/src/main/java/ru/scaik/scammaxdisabler/di/AppModule.kt
+++ b/app/src/main/java/ru/scaik/scammaxdisabler/di/AppModule.kt
@@ -1,0 +1,39 @@
+package ru.scaik.scammaxdisabler.di
+
+import android.content.Context
+import kotlinx.coroutines.CoroutineScope
+import ru.scaik.scammaxdisabler.ScamMaxDisablerApplication
+import ru.scaik.scammaxdisabler.manager.AppIconManager
+import ru.scaik.scammaxdisabler.repository.IconPresetRepository
+import ru.scaik.scammaxdisabler.service.ServiceRestartHelper
+import ru.scaik.scammaxdisabler.state.BlockerStateManager
+import ru.scaik.scammaxdisabler.state.IconPresetStateManager
+import ru.scaik.scammaxdisabler.state.PermissionStateManager
+import ru.scaik.scammaxdisabler.state.ServiceStateManager
+
+interface AppModule {
+    val serviceStateManager: ServiceStateManager
+    val blockerStateManager: BlockerStateManager
+    val permissionStateManager: PermissionStateManager
+    val iconPresetStateManager: IconPresetStateManager
+    val appIconManager: AppIconManager
+    val iconPresetRepository: IconPresetRepository
+    val serviceRestartHelper: ServiceRestartHelper
+    val applicationScope: CoroutineScope
+}
+
+class AppModuleImpl(
+    appContext: Context,
+) : AppModule {
+    override val serviceStateManager by lazy { ServiceStateManager(appContext = appContext) }
+    override val blockerStateManager by lazy { BlockerStateManager(appContext = appContext) }
+    override val permissionStateManager by lazy { PermissionStateManager(appContext = appContext) }
+    override val iconPresetStateManager by lazy { IconPresetStateManager(context = appContext) }
+    override val appIconManager by lazy { AppIconManager(context = appContext) }
+    override val iconPresetRepository by lazy { IconPresetRepository() }
+    override val serviceRestartHelper by lazy { ServiceRestartHelper(context = appContext) }
+    override val applicationScope = (appContext as ScamMaxDisablerApplication).applicationScope
+}
+
+val AppComponent: AppModule
+    get() = (ScamMaxDisablerApplication.appContext as ScamMaxDisablerApplication).appModule

--- a/app/src/main/java/ru/scaik/scammaxdisabler/manager/AppIconManager.kt
+++ b/app/src/main/java/ru/scaik/scammaxdisabler/manager/AppIconManager.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.withContext
 import ru.scaik.scammaxdisabler.model.IconPreset
 import ru.scaik.scammaxdisabler.model.IconPresetId
 
-class AppIconManager private constructor(private val context: Context) {
+class AppIconManager(context: Context) {
 
     private val packageManager = context.packageManager
     private val packageName = context.packageName
@@ -81,14 +81,5 @@ class AppIconManager private constructor(private val context: Context) {
 
     companion object {
         private const val MAIN_ACTIVITY_NAME = "ru.scaik.scammaxdisabler.MainActivity"
-
-        @Volatile private var instance: AppIconManager? = null
-
-        fun getInstance(context: Context): AppIconManager {
-            return instance
-                    ?: synchronized(this) {
-                        instance ?: AppIconManager(context).also { instance = it }
-                    }
-        }
     }
 }

--- a/app/src/main/java/ru/scaik/scammaxdisabler/repository/IconPresetRepository.kt
+++ b/app/src/main/java/ru/scaik/scammaxdisabler/repository/IconPresetRepository.kt
@@ -150,16 +150,4 @@ class IconPresetRepository {
             ),
         )
     }
-
-    companion object {
-        @Volatile
-        private var instance: IconPresetRepository? = null
-
-        fun getInstance(): IconPresetRepository {
-            return instance
-                ?: synchronized(this) {
-                    instance ?: IconPresetRepository().also { instance = it }
-                }
-        }
-    }
 }

--- a/app/src/main/java/ru/scaik/scammaxdisabler/service/AppMonitorService.kt
+++ b/app/src/main/java/ru/scaik/scammaxdisabler/service/AppMonitorService.kt
@@ -10,14 +10,12 @@ import android.view.WindowManager
 import android.view.accessibility.AccessibilityEvent
 import androidx.core.net.toUri
 import ru.scaik.scammaxdisabler.R
-import ru.scaik.scammaxdisabler.ScamMaxDisablerApplication
-import ru.scaik.scammaxdisabler.state.BlockerStateManager
-import ru.scaik.scammaxdisabler.state.ServiceStateManager
+import ru.scaik.scammaxdisabler.di.AppComponent
 
 class AppMonitorService : AccessibilityService() {
 
-    private lateinit var blockerStateManager: BlockerStateManager
-    private lateinit var serviceStateManager: ServiceStateManager
+    private val blockerStateManager = AppComponent.blockerStateManager
+    private val serviceStateManager = AppComponent.serviceStateManager
     private val mainHandler = Handler(Looper.getMainLooper())
 
     private var lastBlockedTimestamp = 0L
@@ -25,19 +23,7 @@ class AppMonitorService : AccessibilityService() {
 
     override fun onCreate() {
         super.onCreate()
-        initializeManagers()
         notifyServiceStarted()
-    }
-
-    private fun initializeManagers() {
-        val application = ScamMaxDisablerApplication.getInstance(this)
-        if (application != null) {
-            blockerStateManager = application.blockerStateManager
-            serviceStateManager = application.serviceStateManager
-        } else {
-            blockerStateManager = BlockerStateManager.getInstance(this)
-            serviceStateManager = ServiceStateManager.getInstance(this)
-        }
     }
 
     private fun notifyServiceStarted() {

--- a/app/src/main/java/ru/scaik/scammaxdisabler/service/WarmUpService.kt
+++ b/app/src/main/java/ru/scaik/scammaxdisabler/service/WarmUpService.kt
@@ -14,32 +14,18 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import ru.scaik.scammaxdisabler.R
-import ru.scaik.scammaxdisabler.ScamMaxDisablerApplication
-import ru.scaik.scammaxdisabler.state.PermissionStateManager
-import ru.scaik.scammaxdisabler.state.ServiceStateManager
+import ru.scaik.scammaxdisabler.di.AppComponent
 
 class WarmUpService : Service() {
 
     private val serviceScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
-    private lateinit var serviceStateManager: ServiceStateManager
-    private lateinit var permissionStateManager: PermissionStateManager
+    private val serviceStateManager = AppComponent.serviceStateManager
+    private val permissionStateManager = AppComponent.permissionStateManager
 
     override fun onCreate() {
         super.onCreate()
-        initializeManagers()
         createNotificationChannel()
         startForeground(NOTIFICATION_ID, createForegroundNotification())
-    }
-
-    private fun initializeManagers() {
-        val application = ScamMaxDisablerApplication.getInstance(this)
-        if (application != null) {
-            serviceStateManager = application.serviceStateManager
-            permissionStateManager = application.permissionStateManager
-        } else {
-            serviceStateManager = ServiceStateManager.getInstance(this)
-            permissionStateManager = PermissionStateManager.getInstance(this)
-        }
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {

--- a/app/src/main/java/ru/scaik/scammaxdisabler/state/BlockerStateManager.kt
+++ b/app/src/main/java/ru/scaik/scammaxdisabler/state/BlockerStateManager.kt
@@ -6,9 +6,14 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
-class BlockerStateManager private constructor(private val context: Context) {
+class BlockerStateManager(appContext: Context) {
 
-    private val applicationContext = context.applicationContext
+    private val sharedPrefs by lazy {
+        appContext.getSharedPreferences(
+            PREFERENCES_NAME,
+            Context.MODE_PRIVATE
+        )
+    }
 
     private val _blockerEnabledState = MutableStateFlow(loadBlockerEnabledState())
     val blockerEnabledState: StateFlow<Boolean> = _blockerEnabledState.asStateFlow()
@@ -61,42 +66,34 @@ class BlockerStateManager private constructor(private val context: Context) {
     }
 
     private fun loadBlockerEnabledState(): Boolean {
-        val preferences =
-                applicationContext.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
-        return preferences.getBoolean(KEY_BLOCKER_ENABLED, DEFAULT_BLOCKER_ENABLED)
+        return sharedPrefs.getBoolean(KEY_BLOCKER_ENABLED, DEFAULT_BLOCKER_ENABLED)
     }
 
     private fun persistBlockerEnabledState(enabled: Boolean) {
-        val preferences =
-                applicationContext.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
-        preferences.edit(commit = true) { putBoolean(KEY_BLOCKER_ENABLED, enabled) }
+        sharedPrefs.edit(commit = true) { putBoolean(KEY_BLOCKER_ENABLED, enabled) }
     }
 
     private fun loadInstallationBlockingEnabledState(): Boolean {
-        val preferences =
-                applicationContext.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
-        return preferences.getBoolean(
-                KEY_INSTALLATION_BLOCKING_ENABLED,
-                DEFAULT_INSTALLATION_BLOCKING_ENABLED
+        return sharedPrefs.getBoolean(
+            KEY_INSTALLATION_BLOCKING_ENABLED,
+            DEFAULT_INSTALLATION_BLOCKING_ENABLED
         )
     }
 
     private fun persistInstallationBlockingEnabledState(enabled: Boolean) {
-        val preferences =
-                applicationContext.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
-        preferences.edit(commit = true) { putBoolean(KEY_INSTALLATION_BLOCKING_ENABLED, enabled) }
+        sharedPrefs.edit(commit = true) {
+            putBoolean(KEY_INSTALLATION_BLOCKING_ENABLED, enabled)
+        }
     }
 
     private fun loadCurrentMode(): Boolean {
-        val preferences =
-                applicationContext.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
-        return preferences.getBoolean(KEY_CURRENT_MODE, DEFAULT_CURRENT_MODE)
+        return sharedPrefs.getBoolean(KEY_CURRENT_MODE, DEFAULT_CURRENT_MODE)
     }
 
     private fun persistCurrentMode(isInstallationMode: Boolean) {
-        val preferences =
-                applicationContext.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
-        preferences.edit(commit = true) { putBoolean(KEY_CURRENT_MODE, isInstallationMode) }
+        sharedPrefs.edit(commit = true) {
+            putBoolean(KEY_CURRENT_MODE, isInstallationMode)
+        }
     }
 
     companion object {
@@ -108,14 +105,5 @@ class BlockerStateManager private constructor(private val context: Context) {
         private const val DEFAULT_INSTALLATION_BLOCKING_ENABLED = false
         private const val DEFAULT_CURRENT_MODE =
                 false // false = active blocking, true = installation blocking
-
-        @Volatile private var instance: BlockerStateManager? = null
-
-        fun getInstance(context: Context): BlockerStateManager {
-            return instance
-                    ?: synchronized(this) {
-                        instance ?: BlockerStateManager(context).also { instance = it }
-                    }
-        }
     }
 }

--- a/app/src/main/java/ru/scaik/scammaxdisabler/state/IconPresetStateManager.kt
+++ b/app/src/main/java/ru/scaik/scammaxdisabler/state/IconPresetStateManager.kt
@@ -7,9 +7,14 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import ru.scaik.scammaxdisabler.model.IconPresetId
 
-class IconPresetStateManager private constructor(private val context: Context) {
+class IconPresetStateManager(context: Context) {
 
-    private val applicationContext = context.applicationContext
+    private val sharedPrefs by lazy {
+        context.getSharedPreferences(
+            PREFERENCES_NAME,
+            Context.MODE_PRIVATE
+        )
+    }
 
     private val _selectedPresetId = MutableStateFlow(loadSelectedPresetId())
     val selectedPresetId: StateFlow<String> = _selectedPresetId.asStateFlow()
@@ -30,29 +35,17 @@ class IconPresetStateManager private constructor(private val context: Context) {
     }
 
     private fun loadSelectedPresetId(): String {
-        val preferences =
-                applicationContext.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
-        return preferences.getString(KEY_SELECTED_PRESET_ID, DEFAULT_PRESET_ID) ?: DEFAULT_PRESET_ID
+        return sharedPrefs.getString(KEY_SELECTED_PRESET_ID, DEFAULT_PRESET_ID)
+            ?: DEFAULT_PRESET_ID
     }
 
     private fun persistSelectedPresetId(presetId: String) {
-        val preferences =
-                applicationContext.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE)
-        preferences.edit(commit = true) { putString(KEY_SELECTED_PRESET_ID, presetId) }
+        sharedPrefs.edit(commit = true) { putString(KEY_SELECTED_PRESET_ID, presetId) }
     }
 
     companion object {
         private const val PREFERENCES_NAME = "icon_preset_prefs"
         private const val KEY_SELECTED_PRESET_ID = "selected_icon_preset_id"
         private val DEFAULT_PRESET_ID = IconPresetId.DEFAULT.value
-
-        @Volatile private var instance: IconPresetStateManager? = null
-
-        fun getInstance(context: Context): IconPresetStateManager {
-            return instance
-                    ?: synchronized(this) {
-                        instance ?: IconPresetStateManager(context).also { instance = it }
-                    }
-        }
     }
 }

--- a/app/src/main/java/ru/scaik/scammaxdisabler/ui/screens/BlockerScreen.kt
+++ b/app/src/main/java/ru/scaik/scammaxdisabler/ui/screens/BlockerScreen.kt
@@ -19,12 +19,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleOwner
 import kotlinx.coroutines.launch
-import ru.scaik.scammaxdisabler.MainActivity
-import ru.scaik.scammaxdisabler.repository.IconPresetRepository
+import ru.scaik.scammaxdisabler.di.AppComponent
 import ru.scaik.scammaxdisabler.ui.components.BlockerView
 import ru.scaik.scammaxdisabler.ui.components.BlockerViewState
 import ru.scaik.scammaxdisabler.ui.components.IconSelectorSheet
@@ -32,13 +32,13 @@ import ru.scaik.scammaxdisabler.ui.components.Permission
 import ru.scaik.scammaxdisabler.utils.BlockerUtils
 
 @Composable
-fun BlockerScreen(context: Context, modifier: Modifier = Modifier) {
-    val activity = context as MainActivity
-    val blockerStateManager = activity.blockerStateManager
-    val iconPresetStateManager = activity.iconPresetStateManager
-    val appIconManager = activity.appIconManager
+fun BlockerScreen(modifier: Modifier = Modifier) {
     val coroutineScope = rememberCoroutineScope()
-    val iconPresetRepository = IconPresetRepository.getInstance()
+    val context = LocalContext.current
+    val blockerStateManager = AppComponent.blockerStateManager
+    val iconPresetStateManager = AppComponent.iconPresetStateManager
+    val iconPresetRepository = AppComponent.iconPresetRepository
+    val appIconManager = AppComponent.appIconManager
 
     var isActiveBlockingEnabled by remember {
         mutableStateOf(blockerStateManager.isBlockerEnabled())

--- a/app/src/main/java/ru/scaik/scammaxdisabler/utils/BlockerUtils.kt
+++ b/app/src/main/java/ru/scaik/scammaxdisabler/utils/BlockerUtils.kt
@@ -10,11 +10,12 @@ import android.util.Log
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.core.net.toUri
-import java.io.File
-import java.io.FileOutputStream
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.launch
+import ru.scaik.scammaxdisabler.di.AppComponent
 import ru.scaik.scammaxdisabler.service.WarmUpService
+import java.io.File
+import java.io.FileOutputStream
 
 object BlockerUtils {
 
@@ -280,7 +281,7 @@ object BlockerUtils {
 
     fun installDummyApkWithCallback(context: Context, onComplete: (Boolean) -> Unit) {
 
-        kotlinx.coroutines.GlobalScope.launch {
+        AppComponent.applicationScope.launch {
             try {
                 // Check if the real package is installed and uninstall it first
                 if (isTargetPackageInstalled(context)) {
@@ -421,7 +422,7 @@ object BlockerUtils {
             context.startActivity(intent)
 
             // Start background monitoring
-            kotlinx.coroutines.GlobalScope.launch {
+            AppComponent.applicationScope.launch {
                 var attempts = 0
                 val maxAttempts = 30 // 30 seconds maximum wait time
 


### PR DESCRIPTION
## Фиксы утечек памяти из-за Context

- Вместо получения зависимостей через синглтоны теперь можно использовать **AppModule** через глобальную переменную-геттер **AppComponent**, который содержит все зависимости с ленивой загрузкой. 
- В **BlockUtils.kt** вместо **GlobalScope** корутины лучше использловать applicationScope, так как **GlobalScope** имеет не всегда очевидное поведение в Android.
- Вся инициализация зависимостей происходит в **AppModule.kt**, исключая использование контекстов из Activity или Service, вызывающих утечку памяти.

```kotlin
class MainActivity : ComponentActivity() {
    // Безопасно использовать без опасения неиницилиазированного Context из Activity
    private val someDependency = AppComponent.someDependency
}
```

```kotlin
@Composable
fun Screen() {
    // Можно использовать в Composable без remember
    val someDependency = AppComponent.someDependency
}
```

> Паттерн синглтонов в Android не совсем подходит для использования вместе с Context. Если хранить его в статичных переменных, то GC просто не будет очищать его из памяти и когда-нибудь приложение упадет от недостатка памяти. Исключением является Context из Application.