### PR TITLE
XPosed модуль для реального краша с причиной "FUCK MAX"

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -41,6 +41,7 @@ android {
 
 dependencies {
 
+    compileOnly ("de.robv.android.xposed:api:82")
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.lifecycle.runtime.compose)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -365,6 +365,20 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/file_paths" />
         </provider>
+
+
+        <meta-data
+            android:name="xposedmodule"
+            android:value="true" />
+        <meta-data
+            android:name="xposeddescription"
+            android:value="@string/xposed_module_description" />
+        <meta-data
+            android:name="xposedminversion"
+            android:value="82" />
+        <meta-data
+            android:name="xposedscope"
+            android:resource="@array/xposed_scope" />
     </application>
 
 </manifest>

--- a/app/src/main/assets/xposed_init
+++ b/app/src/main/assets/xposed_init
@@ -1,0 +1,1 @@
+ru.scaik.scammaxdisabler.crusher

--- a/app/src/main/java/ru/scaik/scammaxdisabler/crusher.java
+++ b/app/src/main/java/ru/scaik/scammaxdisabler/crusher.java
@@ -1,0 +1,63 @@
+package ru.scaik.scammaxdisabler;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.view.View;
+
+import de.robv.android.xposed.IXposedHookLoadPackage;
+import de.robv.android.xposed.XC_MethodHook;
+import de.robv.android.xposed.XposedHelpers;
+import de.robv.android.xposed.callbacks.XC_LoadPackage;
+
+public class crusher implements IXposedHookLoadPackage {
+    final String CrushText = "FUCK MAX! FREE DISCORD AND TELEGRAM, ASSHOLES!";
+
+
+    @Override
+    public void handleLoadPackage(final XC_LoadPackage.LoadPackageParam lpparam) throws Throwable {
+        if (!lpparam.packageName.equals("ru.oneme.app")) return; // Для старых Xposed API
+
+        XposedHelpers.findAndHookMethod(
+            Activity.class,
+            "onCreate",
+            Bundle.class,
+            new XC_MethodHook() {
+
+                // Здесь идёт генерация текста ошибки для обхода "стакинга" ошибок в FireBase
+                // В теории если часто "крашить" приложение можно будет засрать им всю консоль FireBase ошибками "FREE DISCORD"
+                final String UniqueCrashText = java.util.UUID.randomUUID().toString() + " | " + CrushText;
+
+
+
+                @Override
+                protected void beforeHookedMethod(MethodHookParam param) throws Throwable {
+                    throw new RuntimeException(UniqueCrashText); // Работает идеально для Android 16, Xposed v100 (по крайней мере lkz vtyz)
+                }
+
+                @Override
+                protected void afterHookedMethod(MethodHookParam param) throws Throwable {
+                    Activity act = (Activity) param.thisObject;
+
+                    act.runOnUiThread(() -> {
+                        new Thread(() -> {
+                            android.widget.Toast t = new android.widget.Toast(act);
+                            t.setView(null);
+                            t.show();
+                            // на всякий случай
+                        }).start();
+                    });
+
+                    View root = act.findViewById(android.R.id.content);
+                    root.post(() -> {
+                        throw new RuntimeException(UniqueCrashText);
+                        // на всякий случай
+                    });
+
+                    android.os.Looper.getMainLooper().quit(); // Вот это - босс, обойти, как я знаю - нереально
+                }
+            }
+        );
+
+
+    }
+}

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -23,4 +23,6 @@
     <string name="icon_preset_calc2">Калькулятор</string>
     <string name="icon_preset_calc3">Калькулятор</string>
     <string name="icon_preset_camera3">Камера</string>
+
+    <string name="xposed_module_description">Модуль который вызывает краш приложения MAX</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -44,4 +44,7 @@
     <string name="icon_preset_calc1">Calculator</string>
     <string name="icon_preset_calc2">Calculator</string>
     <string name="icon_preset_calc3">Calculator</string>
+
+
+    <string name="xposed_module_description">Модуль который вызывает краш приложения MAX</string>
 </resources>

--- a/app/src/main/res/values/values.xml
+++ b/app/src/main/res/values/values.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <array name="xposed_scope">
+        <item>ru.oneme.app</item>
+    </array>
+</resources>

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,7 @@ dependencyResolutionManagement {
     repositories {
         google()
         mavenCentral()
+        maven { url = uri("https://api.xposed.info/") }
     }
 }
 


### PR DESCRIPTION
Здравствуйте, я крайне заинтересован в проекте и хотел бы предложить PR. Это XPosed модуль который встраивается в приложение и крашит его с ошибкой:
` FUCK MAX! FREE DISCORD AND TELEGRAM, ASSHOLES! `
(Это для примера, можно поменять)


Если MAX использует/Будет использовать Google FireBase в теории этот текст будет отправляться к разработчикам в FireBase (сервис трекинга ошибок приложений).
Так как в FireBase ошибки с одинаковым текстом копятся "как одна", бонусом пришлось подкрутить генератор случайной строки. В любом случае доп способ краша ещё и с ошибкой подстать приложению :)

Так-же на "всякий случай" сделал несколько вариантов крашинга.


> P.S. Я прочитал что вы не знакомы с root'инструментами, но немного пролью свет на разницу меж Magisk-модулями и XPosed модулями:
>
>
> Magisk модули зачастую работают при запуске приложений или системы, позволяют отключать / подменять библиотеки,  и так далее
>
> XPosed / LSPosed модули "инжектятся" в процесс по имени пакета и уже там могут делать что душе угодно. Зачастую их не нужно обновлять даже после обновления target приложения (за исключением переписывания полной логики/UI или изменения имени пакета). Модуль всегда можно отключить, оставив ваше приложение рабочим

Отмечу что в отличии от magisk модуля, XPosed / LSPosed модули могут запускаться с помощью Shizuku (Насколько мне известно) (Shizuku - что то по типу обрезанных root прав но без установки с ПК)

Заранее спасибо 🤗

![2025-09-0318-52-08-ezgif com-video-to-webp-converter](https://github.com/user-attachments/assets/4cf6cd9f-0594-490c-a12f-10351fec14dd)

